### PR TITLE
corrige cor da navegação do questionário no moodle 3.10

### DIFF
--- a/scss/trema/modules.scss
+++ b/scss/trema/modules.scss
@@ -75,6 +75,7 @@ body.path-mod-quiz {
             .qnbutton {
                 padding: 0;
                 text-align: center;
+		color: #000 !important;
             }
 
             button[type="submit"] {


### PR DESCRIPTION
opa! deve ter mudado alguma coisa no css do 3.10, não investiguei muito, mas essa definição funcionou aqui