### PR TITLE
Fixed frontpage-banner-content position on mobile devices

### DIFF
--- a/scss/trema/frontpage.scss
+++ b/scss/trema/frontpage.scss
@@ -85,7 +85,6 @@ body#page-site-index {
         #frontpage-banner #frontpage-banner-content {
             max-width: 80%;
             padding: 1.5rem;
-            position: relative;
             h2 {
                 font-size: 2.3rem;
                 letter-spacing: .8rem;


### PR DESCRIPTION
Removed a faulty line which caused the frontpage-banner-content to go into the header on mobile devices.

I believe it fixes #15 

![trema-fixed](https://user-images.githubusercontent.com/45794420/115470029-f60dd480-a235-11eb-82d7-e4ca7e97f4f1.png)
