### PR TITLE
Fix 73: Language menu is now accesssible

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -82,24 +82,47 @@ class core_renderer extends \theme_boost\output\core_renderer {
     }
 
     /**
-     * Renders the lang menu
+     * Renders the lang menu on the login page.
      *
      * @return mixed
      */
-    public function render_lang_menu() {
+    public function login_lang_menu() {
+        return $this->render_lang_menu(true);
+    }
+
+    /**
+     * Renders the lang menu
+     *
+     * @param bool $showlang Optional false = just the globe, or 'showlang' to force display globe + current language.
+     * @return string Rendered language menu in HTML.
+     */
+    public function render_lang_menu($showlang = false) {
         $langs = get_string_manager()->get_list_of_translations();
         $haslangmenu = $this->lang_menu() != '';
         $menu = new custom_menu;
 
         if ($haslangmenu) {
-            $strlang = get_string('language');
-            $currentlang = current_language();
-            if (isset($langs[$currentlang])) {
-                $currentlang = $langs[$currentlang];
+            $currlang = current_language();
+            if (isset($langs[$currlang])) {
+                $currentlang = $langs[$currlang];
             } else {
-                $currentlang = $strlang;
+                $currentlang = get_string('language');
             }
+
+            // Determine label for top level menu item.
+            if ($showlang) { // Globe + current language name.
+                $strlang = $currentlang;
+            } else { // Just the globe.
+                $strlang = '';
+            }
+            // Add top level menu item.
             $this->language = $menu->add($currentlang, new moodle_url('#'), $strlang, 10000);
+
+            // Make first language in the list the current language.
+            if (isset($langs[$currlang])) {
+                $langs = [ $currlang => $langs[$currlang] ] + $langs;
+            }
+            // Add languages for dropdown menu.
             foreach ($langs as $langtype => $langname) {
                 $lang = str_replace('_', '-', $langtype);
                 $this->language->add($langname, new moodle_url($this->page->url, array('lang' => $langtype)), $lang);

--- a/templates/lang_menu.mustache
+++ b/templates/lang_menu.mustache
@@ -23,22 +23,21 @@
 }}
 {{^divider}}
 {{#haschildren}}
-<span class="dropdown nav-item">
-    <a class="nav-link" id="drop-down-{{uniqid}}" data-toggle="dropdown"
-    aria-haspopup="true" aria-expanded="false" href="#" title="{{#str}} language {{/str}}" aria-label="{{#str}}langmenu,admin{{/str}}">
-        <i area-hidden="true" class="fa fa-globe"></i>
+    <a class="{{#title}}dropdown-toggle {{/title}}nav-link" id="drop-down-{{uniqid}}" data-toggle="dropdown"
+            aria-haspopup="true" aria-expanded="false" href="#" {{^title}}title="{{#str}}language{{/str}}"{{/title}}
+            aria-label="{{#str}}langmenu,admin{{/str}}" aria-controls="drop-down-{{uniqid}}">
+        <i area-hidden="true" class="fa fa-globe"></i>{{#title}} {{{title}}}{{/title}}
     </a>
-    <div class="dropdown-menu" aria-labelledby="drop-down-{{uniqid}}">
+    <div class="dropdown-menu" role="menu" id="drop-down-menu-{{uniqid}}" aria-labelledby="drop-down-{{uniqid}}">
         {{#children}}
             {{^divider}}
-                <a class="dropdown-item" href="{{{url}}}" lang="{{{title}}}">{{text}}</a>
+                <a class="dropdown-item" role="menuitem" href="{{{url}}}" lang="{{{title}}}">{{text}}</a>
             {{/divider}}
             {{#divider}}
                 <div class="dropdown-divider"></div>
             {{/divider}}
         {{/children}}
     </div>
-</span>
 {{/haschildren}}
 {{^haschildren}}
 <a class="nav-item nav-link" href="{{{url}}}" {{#title}}title="{{{title}}}"{{/title}}>{{text}}</a>

--- a/templates/login.mustache
+++ b/templates/login.mustache
@@ -36,7 +36,7 @@
 <div id="page-wrapper">
 
     {{{ output.standard_top_of_body_html }}}
-
+    {{> theme_trema/navbar_login }}
     <div id="page" class="mt-0 pt-0 container-fluid">
         <div id="page-content" class="row">
             <div id="region-main-box" class="col-12">

--- a/templates/navbar_login.mustache
+++ b/templates/navbar_login.mustache
@@ -18,11 +18,6 @@
     Page navbar.
 }}
 <nav class="fixed-top navbar navbar-light bg-white navbar-expand moodle-has-zindex" aria-label="{{#str}}sitemenubar, admin{{/str}}">
-
-        <div data-region="drawer-toggle" class="d-inline-block mr-3">
-            <button aria-expanded="{{#navdraweropen}}true{{/navdraweropen}}{{^navdraweropen}}false{{/navdraweropen}}" aria-controls="nav-drawer" type="button" class="btn nav-link float-sm-left mr-1 btn-secondary" data-action="toggle-drawer" data-side="left" data-preference="drawer-open-nav">{{#pix}}i/menubars{{/pix}}<span class="sr-only">{{#str}}sidepanel, core{{/str}}</span></button>
-        </div>
-
         <a href="{{{ config.wwwroot }}}" class="navbar-brand {{# output.should_display_navbar_logo }}has-logo{{/ output.should_display_navbar_logo }}">
             {{# output.should_display_navbar_logo }}
                 <span class="logo d-inline">
@@ -34,26 +29,9 @@
             {{/ output.should_display_navbar_logo }}
         </a>
 
-        <ul class="navbar-nav trema-custom-menu d-none d-md-flex">
-            <!-- custom_menu -->
-            {{{ output.custom_menu }}}
-            <!-- page_heading_menu -->
-            {{{ output.page_heading_menu }}}
-        </ul>
-        <div class="ml-auto">
-            {{{ output.search_box }}}
-        </div>
-        <ul class="nav navbar-nav usernav">
+        <ul class="nav navbar-nav usernav" style="float:right;">
             <li class="dropdown nav-item">
-            	{{{ output.render_lang_menu }}}
-        	</li>
-            <!-- navbar_plugin_output -->
-            <li class="nav-item">
-            {{{ output.navbar_plugin_output }}}
-            </li>
-            <!-- user_menu -->
-            <li class="nav-item align-items-center">
-                {{{ output.user_menu }}}
+                {{{ output.login_lang_menu }}}
             </li>
         </ul>
         <!-- search_box -->


### PR DESCRIPTION
The following changes were made:

- First item in the language menu is now always the current language.
- When you open the language menu, the first item in the list is always selected.
- The HTML5 in the language menu is now valid.
- The language menu is now displayed on the Login page.

This addresses the accessibility issues reported in issue #73 .

Best regards,

Michael Milette