### PR TITLE
Fix-75: Changed site name on Login page to H1

### DIFF
--- a/templates/core/loginform.mustache
+++ b/templates/core/loginform.mustache
@@ -99,10 +99,10 @@
     <div class="card-block">
         <div class="card-body">
 	        {{#logourl}}
-	            <h2 class="card-header text-center" ><img src="{{logourl}}" class="img-responsive" title="{{sitename}}" alt="{{sitename}}"/></h2>
+	            <h1 class="h2 card-header text-center" ><img src="{{logourl}}" class="img-responsive" title="{{sitename}}" alt="{{sitename}}"/></h1>
 	        {{/logourl}}
 	        {{^logourl}}
-	            <h2 class="card-header text-center">{{sitename}}</h2>
+	            <h1 class="h2 card-header text-center">{{sitename}}</h1>
 	        {{/logourl}}
 
             {{#cansignup}}
@@ -180,7 +180,7 @@
                     {{/canloginasguest}}
 
                 {{#hasidentityproviders}}
-                    <h3 class="h6 mt-2">{{#str}} potentialidps, auth {{/str}}</h3>
+                    <h2 class="h6 mt-2">{{#str}} potentialidps, auth {{/str}}</h2>
                     <div class="potentialidplist" class="mt-3">
                         {{#identityproviders}}
                             <div class="potentialidp">


### PR DESCRIPTION
Hi @rmady ,

This is to address the accessibility issue described in #75 

Let me know if you have any questions.

Michael Milette