### PR TITLE
Fix-79, Fix-80, Fix-83, Fix-92, Fix-93: Language and empty field fixes.

### DIFF
--- a/lang/en/theme_trema.php
+++ b/lang/en/theme_trema.php
@@ -120,7 +120,7 @@ $string['carrouselbtntext_desc'] = 'Button text for link in frontpage image {$a}
 $string['carrouselbtnhref'] = 'Button link {$a}';
 $string['carrouselbtnhref_desc'] = 'Button link for frontpage image {$a}.';
 $string['carrouselbtnclass'] = 'Frontpage button HTML class';
-$string['carrouselbtnclass_desc'] = 'You can change the style of the button choosing another class.';
+$string['carrouselbtnclass_desc'] = 'You can change the style of the button by choosing a different class.';
 $string['frontpageimages'] = 'Frontpage images';
 $string['frontpageimage'] = 'Frontpage image {$a}';
 $string['frontpageimage_desc'] = 'Image {$a} to show in frontpage banner.';
@@ -128,6 +128,39 @@ $string['image'] = 'Image {$a}';
 $string['imagelink'] = 'Image link';
 $string['imagelink_desc'] = 'Button with link in image {$a}.';
 $string['numberofimages']  = "Number of images in frontpage banner";
-$string['numberofimages_desc']  = "Number of images to show in frontpage banner. If is more than one loads the Carrousel.";
+$string['numberofimages_desc']  = "Number of images to show in frontpage banner. If is more than one, loads the carousel.";
 $string['title_desc']  = 'Title to show in frontpage image {$a}';
 $string['subtitle_desc']  = 'Subtitle to show in frontpage image {$a}';
+
+$string['frontpagetitle_default'] = 'Banner title';
+$string['frontpagesubtitle_default'] = 'This is a banner subtitle,<br>with multiple lines of text.';
+$string['frontpagebuttontext_default'] = 'Learn more';
+$string['frontpagecardstitle'] = 'Title of cards section';
+$string['frontpagecardssubtitle'] = 'The description of the cards section goes here. Several lines of text can be placed in this space.';
+$string['cardtitle_default'] = 'Card Title';
+$string['cardsubtitle_default'] = 'The description of this card goes here. Several lines of text can be placed in this space.';
+$string['subtitle_default'] = 'This is the default sub-title. You can modify or remove this in the Trema theme settings.';
+$string['defaultfooter_default'] = '<div class="row">
+	<div class="col-md-8">
+		<h3 class="-align-center">Trema Solutions in Technology</h3>
+
+	</div>
+	<div class="col-md-4">
+		<h3>Contact Us</h3>
+
+		<ul class="labeled-icons">
+			<li>
+                <span class="fa fa-globe fa-2x"></span>
+                <a href="https://trema.tech/" target="_blank" style="cursor: pointer;">
+                    <p>https://trema.tech/</p>
+                </a>
+            </li>
+			<li>
+                <span class="fa fa-github fa-2x"></span>
+                <a href="https://github.com/trema-tech/" target="_blank" style="cursor: pointer;">
+                    <p>https://github.com/trema-tech/</p>
+                </a>
+            </li>
+		</ul>
+	</div>
+</div>';

--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -64,11 +64,11 @@ if ($pluginsettings->numberofimages > 1) {
             $frontpagecarrousel[$i]['image'] = $OUTPUT->image_url('frontpage/banner2', 'theme');
         }
         $frontpagecarrousel[$i]['index']    = $i - 1;
-        $frontpagecarrousel[$i]['title']    = format_text($pluginsettings->$title, FORMAT_HTML);
-        $frontpagecarrousel[$i]['subtitle'] = format_text($pluginsettings->$subtitle, FORMAT_HTML);
-        $frontpagecarrousel[$i]['btntext']  = format_text($pluginsettings->$btntext, FORMAT_HTML);
-        $frontpagecarrousel[$i]['btnhref']  = $pluginsettings->$btnhref;
-        $frontpagecarrousel[$i]['btnclass'] = $pluginsettings->$btnclass;
+        $frontpagecarrousel[$i]['title']    = !empty($pluginsettings->$title) ? format_text($pluginsettings->$title, FORMAT_HTML) : '';
+        $frontpagecarrousel[$i]['subtitle'] = !empty($pluginsettings->$subtitle) ? format_text($pluginsettings->$subtitle, FORMAT_HTML) : '';
+        $frontpagecarrousel[$i]['btntext']  = !empty($pluginsettings->$btntext) ? format_text($pluginsettings->$btntext, FORMAT_HTML) : '';
+        $frontpagecarrousel[$i]['btnhref']  = !empty($pluginsettings->$btnhref) ? $pluginsettings->$btnhref : '';
+        $frontpagecarrousel[$i]['btnclass'] = !empty($pluginsettings->$btnclass) ? $pluginsettings->$btnclass : '';
         // Must have just one slide active.
         if ($active) {
             $frontpagecarrousel[$i]['active'] = "active";
@@ -95,17 +95,17 @@ $templatecontext = [
     'navdraweropen' => $navdraweropen,
     'regionmainsettingsmenu' => $regionmainsettingsmenu,
     'hasregionmainsettingsmenu' => ! empty($regionmainsettingsmenu),
-    'defaultfrontpagebody' => format_text($pluginsettings->defaultfrontpagebody, FORMAT_HTML),
-    'defaultfrontpagefooter' => format_text($pluginsettings->defaultfooter, FORMAT_HTML),
+    'defaultfrontpagebody' => !empty($pluginsettings->defaultfrontpagebody) ? format_text($pluginsettings->defaultfrontpagebody, FORMAT_HTML) : '',
+    'defaultfrontpagefooter' => !empty($pluginsettings->defaultfooter) ? format_text($pluginsettings->defaultfooter, FORMAT_HTML) : '',
     'frontpagecarrousel' => $frontpagecarrousel,
-    'frontpagetitle' => format_text($pluginsettings->frontpagetitle, FORMAT_HTML),
-    'frontpagesubtitle' => format_text($pluginsettings->frontpagesubtitle, FORMAT_HTML),
-    'frontpagebuttontext' => format_text($pluginsettings->frontpagebuttontext, FORMAT_HTML),
-    'frontpagebuttonclass' => $pluginsettings->frontpagebuttonclass,
-    'frontpagebuttonhref' => $pluginsettings->frontpagebuttonhref,
-    'hascards' => $pluginsettings->frontpageenablecards,
-    'cardstitle' => format_text($pluginsettings->frontpagecardstitle, FORMAT_HTML),
-    'cardssubtitle' => format_text($pluginsettings->frontpagecardssubtitle, FORMAT_HTML),
+    'frontpagetitle' => !empty($pluginsettings->frontpagetitle) ? format_text($pluginsettings->frontpagetitle, FORMAT_HTML) : '',
+    'frontpagesubtitle' => !empty($pluginsettings->frontpagesubtitle) ? format_text($pluginsettings->frontpagesubtitle, FORMAT_HTML) : '',
+    'frontpagebuttontext' => !empty($pluginsettings->frontpagebuttontext) ? format_text($pluginsettings->frontpagebuttontext, FORMAT_HTML) : '',
+    'frontpagebuttonclass' => !empty($pluginsettings->frontpagebuttonclass) ? $pluginsettings->frontpagebuttonclass : '',
+    'frontpagebuttonhref' => !empty($pluginsettings->frontpagebuttonhref) ? $pluginsettings->frontpagebuttonhref : '',
+    'hascards' => !empty($pluginsettings->frontpageenablecards),
+    'cardstitle' => !empty($pluginsettings->frontpagecardstitle) ? format_text($pluginsettings->frontpagecardstitle, FORMAT_HTML) : '',
+    'cardssubtitle' => !empty($pluginsettings->frontpagecardssubtitle) ? format_text($pluginsettings->frontpagecardssubtitle, FORMAT_HTML) : '',
     'cardssettings' => theme_trema_get_cards_settings(),
     'footerinfo' => $pluginsettings->enablefooterinfo
 ];

--- a/lib.php
+++ b/lib.php
@@ -311,7 +311,7 @@ function theme_trema_setting_file_url($setting, $filearea, $theme) {
 
     $component  = 'theme_trema';
     $itemid     = 0;
-    $filepath   = $theme->settings->$filearea;
+    $filepath   = !empty($theme->settings->$filearea) ? $theme->settings->$filearea : '';
 
     if (empty($filepath)) {
         return false;

--- a/settings/content_settings.php
+++ b/settings/content_settings.php
@@ -35,7 +35,7 @@ $page->add(new admin_setting_heading('theme_trema_frontpageimages',
 $name = 'theme_trema/numberofimages';
 $title = get_string('numberofimages', 'theme_trema');
 $description = get_string('numberofimages_desc', 'theme_trema');
-$default = 1; // Carrousel disable.
+$default = 1; // Carousel disable.
 $choices = [
     1 => '1',
     2 => '2',
@@ -57,8 +57,25 @@ $btnchoices = array(
     "btn-dark" => "btn-dark"
 );
 
-$numberofcarrousel = get_config('theme_trema', 'numberofimages');
-if ($numberofcarrousel == 1) {
+$numberofcarousel = get_config('theme_trema', 'numberofimages');
+
+$frontpagetitle_default = new lang_string('frontpagetitle_default', 'theme_trema');
+$frontpagesubtitle_default = new lang_string('frontpagesubtitle_default', 'theme_trema');
+$frontpagebuttontext_default = new lang_string('frontpagebuttontext_default', 'theme_trema');
+$cardtitle_default = get_string('cardtitle', 'theme_trema');
+$cardsubtitle_default = get_string('cardsubtitle', 'theme_trema');
+
+// Set some settings so that they can initially have a default value but later be set blank.
+if (empty($numberofcarousel)) {
+    // Initialize some values.
+    $numberofcarousel = 1;
+    set_config('frontpagetitle_default', $frontpagetitle_default, 'theme_trema');
+    set_config('frontpagesubtitle_default', $frontpagesubtitle_default, 'theme_trema');
+    set_config('frontpagebuttontext_default', $frontpagebuttontext_default, 'theme_trema');
+    set_config('cardtitle_default', $cardtitle_default, 'theme_trema');
+}
+
+if ($numberofcarousel == 1) {
     // Frontpage single banner.
     $name = 'theme_trema/frontpagebanner';
     $title = get_string('frontpagebanner', 'theme_trema');
@@ -70,23 +87,24 @@ if ($numberofcarrousel == 1) {
     // Frontpage title.
     $page->add(
         new admin_setting_configtext('theme_trema/frontpagetitle', new lang_string('frontpagetitle', 'theme_trema'), '',
-            'Lorem ipsum, dolor sit amet'));
+        $frontpagetitle_default));
 
     // Frontpage subtitle.
     $page->add(
         new admin_setting_configtext('theme_trema/frontpagesubtitle', new lang_string('frontpagesubtitle', 'theme_trema'), '',
-            'Ut enim ad minim veniam,<br> quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'));
+        $frontpagesubtitle_default));
 
     // Frontpage button text.
     $page->add(
         new admin_setting_configtext('theme_trema/frontpagebuttontext', new lang_string('frontpagebuttontext', 'theme_trema'), '',
-            'Learn more'));
+        $frontpagebuttontext_default));
 
-    // Frontpage button href.
+    // Frontpage button link.
     $page->add(
         new admin_setting_configtext('theme_trema/frontpagebuttonhref', new lang_string('frontpagebuttonhref', 'theme_trema'),
             new lang_string('frontpagebuttonhref_desc', 'theme_trema'), '#frontpage-cards'));
 
+    // Frontpage button class.
     $setting = new admin_setting_configselect('theme_trema/frontpagebuttonclass',
         new lang_string('frontpagebuttonclass', 'theme_trema'), new lang_string('frontpagebuttonclass_desc', 'theme_trema'),
         'btn-primary', $btnchoices);
@@ -94,10 +112,10 @@ if ($numberofcarrousel == 1) {
 
 } else {
 
-    for ($i = 1; $i <= $numberofcarrousel; $i ++) {
+    for ($i = 1; $i <= $numberofcarousel; $i ++) {
         $page->add(new admin_setting_heading("theme_trema_frontpageimage{$i}" ,
             get_string('frontpageimage', 'theme_trema', $i), '', FORMAT_MARKDOWN));
-        // Carrousel image.
+        // Carousel image.
         $name = "theme_trema/frontpageimage{$i}";
         $title = get_string('image', 'theme_trema', $i);
         $description = get_string('frontpageimage_desc', 'theme_trema', $i);
@@ -105,31 +123,34 @@ if ($numberofcarrousel == 1) {
         $setting->set_updatedcallback('theme_reset_all_caches');
         $page->add($setting);
 
-        // Carrousel title.
+        // Carousel title.
         $name = 'theme_trema/carrouseltitle' . $i;
         $title = get_string('title', 'theme_trema') . " $i";
         $description = get_string('title_desc', 'theme_trema', $i);
-        $default = 'MAGNA ETIAM';
+        $default = new lang_string('frontpagetitle_default', 'theme_trema');
         $page->add(new admin_setting_configtext($name, $title, $description, $default));
 
-        // Carrousel description.
+        // Carousel description.
         $name = 'theme_trema/carrouselsubtitle' . $i;
         $title = get_string('subtitle', 'theme_trema') . " $i";
         $description = get_string('subtitle_desc', 'theme_trema', $i);
-        $default = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem accusantium! Harum optio, volup.';
+        $default = new lang_string('frontpagesubtitle_default', 'theme_trema');
         $page->add(new admin_setting_configtext($name, $title, $description, $default));
 
-        // Carrousel link.
+        // Carousel button text.
         $name = 'theme_trema/carrouselbtntext' . $i;
         $title = get_string('carrouselbtntext', 'theme_trema', $i);
         $description = get_string('carrouselbtntext_desc', 'theme_trema', $i);
-        $page->add(new admin_setting_configtext($name, $title, $description, ''));
+        $default = new lang_string('frontpagebuttontext_default', 'theme_trema');
+        $page->add(new admin_setting_configtext($name, $title, $description, $default));
 
+        // Carousel button link.
         $name = 'theme_trema/carrouselbtnhref' . $i;
         $title = get_string('carrouselbtnhref', 'theme_trema', $i);
         $description = get_string('carrouselbtnhref_desc', 'theme_trema', $i);
         $page->add(new admin_setting_configtext($name, $title, $description, ''));
 
+        // Carousel button class.
         $name = 'theme_trema/carrouselbtnclass' . $i;
         $title = get_string('carrouselbtnclass', 'theme_trema', $i);
         $description = get_string('carrouselbtnclass_desc', 'theme_trema', $i);
@@ -158,15 +179,14 @@ if (get_config('theme_trema', 'frontpageenablecards')) {
     $name = 'theme_trema/frontpagecardstitle';
     $title = get_string('title', 'theme_trema');
     $description = '';
-    $page->add(new admin_setting_configtext($name, $title, $description, 'MAGNA ETIAM ADIPISCING'));
+    $page->add(new admin_setting_configtext($name, $title, $description, get_string('cardtitle', 'theme_trema')));
 
     // Subtitle.
     $name = 'theme_trema/frontpagecardssubtitle';
     $title = get_string('subtitle', 'theme_trema');
     $description = '';
     $page->add(
-        new admin_setting_configtext($name, $title, $description,
-            'Consequat sed ultricies rutrum. Sed adipiscing eu amet utem blandit vis ac commodo aliquet vulputate.'));
+        new admin_setting_configtext($name, $title, $description, get_string('cardsubtitle', 'theme_trema')));
 
     // Number of cards.
     $name = 'theme_trema/numberofcards';
@@ -183,17 +203,17 @@ if (get_config('theme_trema', 'frontpageenablecards')) {
     $numberofcards = get_config('theme_trema', 'numberofcards');
     for ($i = 1; $i <= $numberofcards; $i ++) {
         // Card header.
-        $page->add(new admin_setting_heading('theme_trema_card' . $i, get_string('card', 'theme_trema') . $i, ''));
+        $page->add(new admin_setting_heading('theme_trema_card' . $i, get_string('card', 'theme_trema') . ' ' . $i, ''));
 
         // Card icon.
         $name = 'theme_trema/cardicon' . $i;
-        $title = get_string('cardicon', 'theme_trema') . $i;
+        $title = get_string('cardicon', 'theme_trema') . ' ' . $i;
         $description = get_string('cardicon_desc', 'theme_trema');
         $page->add(new admin_setting_configtext($name, $title, $description, 'fa-paper-plane'));
 
         // Card icon color.
         $name = 'theme_trema/cardiconcolor' . $i;
-        $title = get_string('cardiconcolor', 'theme_trema') . $i;
+        $title = get_string('cardiconcolor', 'theme_trema') . ' ' . $i;
         $description = '';
         $setting = new admin_setting_configcolourpicker($name, $title, $description, '#000000');
         $setting->set_updatedcallback('theme_reset_all_caches');
@@ -201,21 +221,19 @@ if (get_config('theme_trema', 'frontpageenablecards')) {
 
         // Card title.
         $name = 'theme_trema/cardtitle' . $i;
-        $title = get_string('cardtitle', 'theme_trema') . $i;
+        $title = $cardtitle_default . ' ' . $i;
         $description = '';
-        $page->add(new admin_setting_configtext($name, $title, $description, 'MAGNA ETIAM'));
+        $page->add(new admin_setting_configtext($name, $title, $description, get_string('cardtitle_default', 'theme_trema') .  ' ' . $i));
 
         // Card description.
         $name = 'theme_trema/cardsubtitle' . $i;
-        $title = get_string('cardsubtitle', 'theme_trema') . $i;
+        $title = $cardsubtitle_default . ' ' . $i;
         $description = '';
-        $page->add(
-            new admin_setting_configtext($name, $title, $description,
-                'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem accusantium! Harum optio, volup.'));
+        $page->add(new admin_setting_configtext($name, $title, $description, get_string('cardsubtitle_default', 'theme_trema')));
 
         // Card link.
         $name = 'theme_trema/cardlink' . $i;
-        $title = get_string('cardlink', 'theme_trema') . $i;
+        $title = get_string('cardlink', 'theme_trema') . ' ' . $i;
         $description = '';
         $page->add(new admin_setting_configtext($name, $title, $description, ''));
     }

--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -53,17 +53,17 @@
                         <div class="frontpage-banner-content">
                             {{#title}}<h2 class="pb-4 pl-3 mb-3">{{title}}</h2>{{/title}}
                             {{#subtitle}}<h3 class="mb-3 d-none d-md-block">{{subtitle}}</h3>{{/subtitle}}
-                            {{#btnhref}}<a href="{{btnhref}}" class="m-3 btn d-none d-md-inline-block {{btnclass}}" role="button">{{btntext}}</a>{{/btnhref}}
+                            {{#btntext}}{{#btnhref}}<a href="{{btnhref}}" class="m-3 btn d-none d-md-inline-block {{btnclass}}" role="button">{{{btntext}}}</a>{{/btnhref}}{{/btntext}}
                         </div>
                     </div>
                 {{/frontpagecarrousel}}
                     <a class="carousel-control-prev" href="#carouselTrema" role="button" data-slide="prev">
                         <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                        <span class="sr-only">Previous</span>
+                        <span class="sr-only">{{#str}} previous, core {{/str}}</span>
                     </a>
                     <a class="carousel-control-next" href="#carouselTrema" role="button" data-slide="next">
                         <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                        <span class="sr-only">Next</span>
+                        <span class="sr-only">{{#str}} next, core {{/str}}</span>
                     </a>
                 </div>
             </div>
@@ -71,9 +71,9 @@
         {{^frontpagecarrousel}}
         <div id="frontpage-banner">
             <div id="frontpage-banner-content">
-	            <h2 class="pb-4 pl-3 mb-3">{{{frontpagetitle}}}</h2>
-	            <h3 class="mb-3">{{{frontpagesubtitle}}}</h3>
-	            <a href="{{frontpagebuttonhref}}" class="m-3 btn {{frontpagebuttonclass}}" role="button">{{frontpagebuttontext}}</a>
+	            {{#frontpagetitle}}<h2 class="pb-4 pl-3 mb-3">{{{frontpagetitle}}}</h2>{{/frontpagetitle}}
+	            {{#frontpagesubtitle}}<h3 class="mb-3">{{{frontpagesubtitle}}}</h3>{{/frontpagesubtitle}}
+	            {{#frontpagebuttontext}}{{#frontpagebuttonhref}}<a href="{{frontpagebuttonhref}}" class="m-3 btn {{frontpagebuttonclass}}" role="button">{{{frontpagebuttontext}}}</a>{{/frontpagebuttonhref}}{{/frontpagebuttontext}}
             </div>
             {{{ output.frontpage_settings_menu }}}
         </div>
@@ -84,10 +84,14 @@
 
             <div id="frontpage-cards-title" class="row mx-3 p-4 pt-0 text-center">
                 <div class="col-12 pt-3 pb-3">
+                    {{#cardstitle}}
                     <h2 class="border-bottom p-3 m-2 mb-4">{{{cardstitle}}}</h2>
+                    {{/cardstitle}}
+                    {{#cardssubtitle}}
                     <p class="font-weight-light">
                         {{{cardssubtitle}}}
                     </p>
+                    {{/cardssubtitle}}
                 </div>
             </div>
 
@@ -95,8 +99,8 @@
             {{#cardssettings}}
             <div class="frontpage-card col-sm-6 p-4 text-center">
                     {{#cardlink}}<a href="{{cardlink}}">{{/cardlink}}<span class="fa {{cardicon}} fa-4x" style="color: {{cardiconcolor}};"></span>{{#cardlink}}</a>{{/cardlink}}
-                    {{#cardlink}}<a href="{{cardlink}}">{{/cardlink}}<h3>{{cardtitle}}</h3>{{#cardlink}}</a>{{/cardlink}}
-                    <p class="font-weight-light">{{cardsubtitle}}</p>
+                    {{#cardlink}}<a href="{{cardlink}}">{{/cardlink}}<h3>{{{cardtitle}}}</h3>{{#cardlink}}</a>{{/cardlink}}
+                    <p class="font-weight-light">{{{cardsubtitle}}}</p>
                 </div>
                 {{/cardssettings}}
             </div>


### PR DESCRIPTION
This pull request addresses multi-language issues and bugs mentioned in the following list of  issues:

- #79 Undefined property: stdClass::$frontpagecardstitle and $frontpagecardssubtitle on front page.
- #80 Default strings in Trema settings should be the current UI language.
- #83 Blanking Frontpage banner/carousel button text should also remove button/link.
- #92 Error when any of the carousel banner field settings are empty.
- #93 Carousel Previous and Next controls are only in English.

It also fixes a few typos in the English strings.

Please review and let me know if you require any changes.

Best regards,

Michael Milette