### PR TITLE
Fix-86: Frontpage now has hidden H1 but only read by screen readers.

### DIFF
--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -39,41 +39,40 @@
     {{>theme_trema/navbar}}
 
     <div id="page" class="container-fluid">
+        <h1 class="sr-only container pb-0 mb-0 mt-5">{{sitename}}</h1>
+        {{#frontpagecarrousel}}
+        <div id="carouselTrema" class="carousel slide carousel-fade" data-ride="carousel">
+            <div class="carousel-inner" data-interval="false">
+                <ol class="carousel-indicators">
+                        <li data-target="#carouselTrema" data-slide-to="{{index}}" class="{{active}}"></li>
+                </ol>
 
-        <div id="carouselTrema" class="carousel slide carousel-fade {{^frontpagecarrousel}}d-none{{/frontpagecarrousel}}" data-ride="carousel">
-                <div class="carousel-inner" data-interval="false">
-                    <ol class="carousel-indicators">
-                        {{#frontpagecarrousel}}
-                            <li data-target="#carouselTrema" data-slide-to="{{index}}" class="{{active}}"></li>
-                        {{/frontpagecarrousel}}
-                    </ol>
-                {{#frontpagecarrousel}}
-                    <div class="carousel-item {{active}}">
-                        <img src="{{image}}" class="d-block w-100" alt="{{title}}">
-                        <div class="frontpage-banner-content">
-                            {{#title}}<h2 class="pb-4 pl-3 mb-3">{{title}}</h2>{{/title}}
-                            {{#subtitle}}<h3 class="mb-3 d-none d-md-block">{{subtitle}}</h3>{{/subtitle}}
-                            {{#btnhref}}<a href="{{btnhref}}" class="m-3 btn d-none d-md-inline-block {{btnclass}}" role="button">{{btntext}}</a>{{/btnhref}}
-                        </div>
+                <div class="carousel-item {{active}}">
+                    <img src="{{image}}" class="d-block w-100" alt="{{title}}">
+                    <div class="frontpage-banner-content">
+                        {{#title}}<h2 class="pb-4 pl-3 mb-3">{{title}}</h2>{{/title}}
+                        {{#subtitle}}<h3 class="mb-3 d-none d-md-block">{{subtitle}}</h3>{{/subtitle}}
+                        {{#btnhref}}<a href="{{btnhref}}" class="m-3 btn d-none d-md-inline-block {{btnclass}}" role="button">{{btntext}}</a>{{/btnhref}}
                     </div>
-                {{/frontpagecarrousel}}
-                    <a class="carousel-control-prev" href="#carouselTrema" role="button" data-slide="prev">
-                        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                        <span class="sr-only">Previous</span>
-                    </a>
-                    <a class="carousel-control-next" href="#carouselTrema" role="button" data-slide="next">
-                        <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                        <span class="sr-only">Next</span>
-                    </a>
                 </div>
-            </div>
 
+                <a class="carousel-control-prev" href="#carouselTrema" role="button" data-slide="prev">
+                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="sr-only">Previous</span>
+                </a>
+                <a class="carousel-control-next" href="#carouselTrema" role="button" data-slide="next">
+                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="sr-only">Next</span>
+                </a>
+            </div>
+        </div>
+        {{/frontpagecarrousel}}
         {{^frontpagecarrousel}}
         <div id="frontpage-banner">
             <div id="frontpage-banner-content">
-	            <h2 class="pb-4 pl-3 mb-3">{{{frontpagetitle}}}</h2>
-	            <h3 class="mb-3">{{{frontpagesubtitle}}}</h3>
-	            <a href="{{frontpagebuttonhref}}" class="m-3 btn {{frontpagebuttonclass}}" role="button">{{frontpagebuttontext}}</a>
+                <h2 class="pb-4 pl-3 mb-3">{{{frontpagetitle}}}</h2>
+                <h3 class="mb-3">{{{frontpagesubtitle}}}</h3>
+                <a href="{{frontpagebuttonhref}}" class="m-3 btn {{frontpagebuttonclass}}" role="button">{{frontpagebuttontext}}</a>
             </div>
             {{{ output.frontpage_settings_menu }}}
         </div>


### PR DESCRIPTION
This addresses the issue reported in #86. Notes:

- The new page title is in a hidden page title which is only read by screen readers.
- The page title is present regardless of whether you are displaying a banner or carousel.
- The mustache code for the banner/carousel has been refactored slightly. It is now simpler and parts of the carousel are no longer left behind when displaying a single banner.

Let me know if you have any questions or concerns.

Best regards,

Michael