### PR TITLE
Fix-109: Added setting option for no background on login page.

### DIFF
--- a/layout/login.php
+++ b/layout/login.php
@@ -29,7 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 // Check if the login page are using particles or image background.
 $loginstyle = get_config('theme_trema', 'loginpagestyle');
 $additionalclasses = [
-    $loginstyle == "particle-circles" ? 'style-particles' : 'style-image'
+    $loginstyle == "particle-circles" ? 'style-particles' : ($loginstyle == 'image' ? 'style-image' : 'style-none')
 ];
 $bodyattributes = $OUTPUT->body_attributes($additionalclasses);
 
@@ -51,4 +51,3 @@ $templatecontext = [
 ];
 
 echo $OUTPUT->render_from_template('theme_trema/login', $templatecontext);
-

--- a/scss/trema/login.scss
+++ b/scss/trema/login.scss
@@ -45,5 +45,10 @@ body#page-login-index {
             background-size: cover;
         }
     }
-}
 
+    &.style-none {
+        #page-wrapper {
+            background-image: none;
+        }
+    }
+}

--- a/settings/login_settings.php
+++ b/settings/login_settings.php
@@ -31,7 +31,8 @@ $page = new admin_settingpage('theme_trema_login', get_string('login', 'theme_tr
 // Login page style.
 $choices = array(
     "particle-circles" => get_string('particlecircles', 'theme_trema'),
-    "image" => get_string('image', 'theme_trema')
+    "image" => get_string('image', 'theme_trema'),
+    "none" => get_string('none')
 );
 $setting = new admin_setting_configselect('theme_trema/loginpagestyle', get_string('loginpagestyle', 'theme_trema'), '',
     'particle-circles', $choices);


### PR DESCRIPTION
This pull request addresses the issue reported in #109 .

It adds a **None** option to the list offered in the **Login Page Style** setting of the Trema theme. When **None** is selected, no background will be applied to the login page.

Let me know if you have any questions or concerns.

Best regards,

Michael Milette