### PR TITLE
Fix_#106: Always show password reset link on login form

### DIFF
--- a/templates/core/loginform.mustache
+++ b/templates/core/loginform.mustache
@@ -178,17 +178,17 @@
                         <div class="text-center mb-2">
                             <button type="submit" class="btn btn-primary btn-block" id="loginbtn">{{#str}}login{{/str}}</button>
                         </div>
-                        {{#rememberusername}}
-                            <div class="row text-center">
-                                <div class="rememberpass col-md-6">
+                        <div class="row text-center">                        
+                            {{#rememberusername}}
+                                <div class="rememberpass col">
                                     <input type="checkbox" name="rememberusername" id="rememberusername" value="1" {{#username}}checked="checked"{{/username}} />
                                     <label for="rememberusername">{{#str}} rememberusername, theme_trema {{/str}}</label>
                                 </div>
-                                <div class="forgetpass col-md-6">
-                                    <p><a href="{{forgotpasswordurl}}">{{#str}}forgotten{{/str}}</a></p>
-                                </div>
+                            {{/rememberusername}}
+                            <div class="forgetpass col">
+                            	<p><a href="{{forgotpasswordurl}}">{{#str}}forgotten{{/str}}</a></p>
                             </div>
-                        {{/rememberusername}}
+                        </div>
                     </form>
 
                 </div>


### PR DESCRIPTION
Link to the configured forgotpasswordurl is displayed regardless of the moodle-setting rememberusername.