### PR TITLE
Fix_#113: Added class aalink to coursenamelink in coursecards

### DIFF
--- a/classes/output/core/course_renderer.php
+++ b/classes/output/core/course_renderer.php
@@ -209,7 +209,7 @@ class course_renderer extends \core_course_renderer {
         $coursename = $chelper->get_course_formatted_name($course);
         $courseurl = new moodle_url('/course/view.php', array('id' => $course->id));
         $coursenamelink = html_writer::link($courseurl,
-            $coursename, array('class' => $course->visible ? '' : 'dimmed'));
+            $coursename, array('class' => $course->visible ? 'aalink' : 'aalink dimmed'));
 
         $content = html_writer::start_tag('a', array ('href' => $courseurl, 'class' => 'course-card-img'));
         $content .= $this->get_course_summary_image($course);


### PR DESCRIPTION
The coursenamelink within a coursecard now always contains HTML-Attribute class="aalink". This causes the browser to properly highlight the link when he gets focussed (as most other links in moodle), which is important for the use of keyboard navigation.