### PR TITLE
Fix-125: Added option to add/remove shading on front page banner.

### DIFF
--- a/lang/en/theme_trema.php
+++ b/lang/en/theme_trema.php
@@ -74,6 +74,8 @@ $string['frontpagecards'] = 'Frontpage cards';
 $string['frontpagecontent'] = 'Frontpage Content';
 $string['frontpageenablecards'] = 'Enable frontpage cards';
 $string['frontpageenablecards_desc'] = 'Uncheck if you want to hide the area below: <img class="img-responsive" src="{$a}" />';
+$string['frontpageenabledarkoverlay'] = 'Frontpage banner dark overlay';
+$string['frontpageenabledarkoverlay_desc'] = 'When enabled, this will apply a dark overlay to the banner on the front page.';
 $string['frontpagesubtitle'] = 'Frontpage subtitle.';
 $string['frontpagetitle'] = 'Frontpage title.';
 $string['image'] = 'Background image';

--- a/lib.php
+++ b/lib.php
@@ -50,12 +50,16 @@ function theme_trema_get_main_scss_content($theme) {
     }
 
     // Frontpage banner.
-    if ($frontpagebannerurl = $theme->setting_file_url('frontpagebanner', 'frontpagebanner')) {
-        $scss .= "#frontpage-banner {background-image: url([[pix:theme|frontpage/overlay]]), url('$frontpagebannerurl');}";
+    if (!empty($theme->settings->frontpageenabledarkoverlay)) {
+        $darkoverlay = "url([[pix:theme|frontpage/overlay]]),";
     } else {
-        $scss .= "#frontpage-banner {background-image: url([[pix:theme|frontpage/overlay]]), url([[pix:theme|frontpage/banner]]);}";
+        $darkoverlay = "";
     }
-
+    if ($frontpagebannerurl = $theme->setting_file_url('frontpagebanner', 'frontpagebanner')) {
+        $scss .= "#frontpage-banner {background-image: $darkoverlay url('$frontpagebannerurl');}";
+    } else {
+        $scss .= "#frontpage-banner {background-image: $darkoverlay url([[pix:theme|frontpage/banner]]);}";
+    }
     return $scss;
 }
 

--- a/settings/content_settings.php
+++ b/settings/content_settings.php
@@ -158,6 +158,14 @@ if ($numberofcarousel == 1) {
     }
 }
 
+// Enable/disable dark overlay on banner.
+$name = 'theme_trema/frontpageenabledarkoverlay';
+$title = get_string('frontpageenabledarkoverlay', 'theme_trema');
+$description = get_string('frontpageenabledarkoverlay_desc', 'theme_trema');
+$default = true;
+$setting = new admin_setting_configcheckbox($name, $title, $description, $default, true, false);
+$page->add($setting);
+
 // HTML to include in the main content of frontpage.
 $setting = new admin_setting_confightmleditor('theme_trema/defaultfrontpagebody', get_string('defaultfrontpagebody', 'theme_trema'),
     get_string('defaultfrontpagebody_desc', 'theme_trema'), '', PARAM_RAW);

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022071900;
+$plugin->version   = 2022071901;
 $plugin->release   = '4.0.0.1';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2022021800; // Moodle 4.0 - Build: 20220218.


### PR DESCRIPTION
This is to address feature request #125 .

Note: The default is to apply the shading so that it doesn't change on existing instances of Moodle with Trema.

Best regards,

Michael Milette