### PR TITLE
Added class aalink to coursenamelink in coursecards

### DIFF
--- a/classes/output/core/course_renderer.php
+++ b/classes/output/core/course_renderer.php
@@ -198,7 +198,7 @@ class course_renderer extends \core_course_renderer {
         $coursename = $chelper->get_course_formatted_name($course);
         $courseurl = new moodle_url('/course/view.php', array('id' => $course->id));
         $coursenamelink = html_writer::link($courseurl,
-            $coursename, array('class' => $course->visible ? '' : 'dimmed'));
+            $coursename, array('class' => $course->visible ? 'aalink' : 'aalink dimmed'));
 
         $content = html_writer::start_tag('a', array ('href' => $courseurl, 'class' => 'course-card-img'));
         $content .= $this->get_course_summary_image($course);


### PR DESCRIPTION
This is to apply fix #113 to the latest version of the theme. It also addresses issue #120 .