### PR TITLE
Fix 151: Enable filtering of defaultfooter on dashboard.

### DIFF
--- a/layout/mydashboard.php
+++ b/layout/mydashboard.php
@@ -85,7 +85,7 @@ $templatecontext = [
     'addblockbutton' => $addblockbutton,
     'regionmainsettingsmenu' => $regionmainsettingsmenu,
     'hasregionmainsettingsmenu' => !empty($regionmainsettingsmenu),
-    'defaultfrontpagefooter' => $pluginsettings->defaultfooter,
+    'defaultfrontpagefooter' => format_text($pluginsettings->defaultfooter, FORMAT_HTML, ['context' => $context]),
     'enabletremafooter' => $pluginsettings->enabletremafooter,
     'footerinfo' => format_text($pluginsettings->enablefooterinfo, FORMAT_HTML, ['context' => $context]),
 ];


### PR DESCRIPTION
This is to address the issue reported in #151 . After this fix has been applied, the content of defaultfooter will be processed through Moodle filters.
![image](https://user-images.githubusercontent.com/3808579/189241312-a6d02e16-d18b-4703-a79a-16df3b615933.png)
