### PR TITLE
Fix-108: Added option to hide courses in hidden categories.

### DIFF
--- a/lang/en/theme_trema.php
+++ b/lang/en/theme_trema.php
@@ -110,6 +110,8 @@ $string['summarytype_desc'] = 'Choose whether the course summary will open in a 
 $string['title'] = 'Title';
 $string['total'] = 'Total';
 $string['subtitle'] = 'Subtitle';
+$string['showehiddencategorycourses'] = 'Show courses in hidden categories';
+$string['showehiddencategorycourses_desc'] = 'Deselect this option to hide courses if they are in or in a hidden category or under one or more hidden parent categories. These courses will still be available by direct URL, if the user has the capability to view hidden categories or edit/update the course.';
 
 // Strings copied from Boost.
 $string['advancedsettings'] = 'Advanced settings';

--- a/settings/content_settings.php
+++ b/settings/content_settings.php
@@ -285,4 +285,13 @@ $default = false;
 $setting = new admin_setting_configcheckbox($name, $title, $description, $default, true, false);
 $page->add($setting);
 
+// Show categories on Frontpage course cards.
+$name = 'theme_trema/showehiddencategorycourses';
+$title = get_string('showehiddencategorycourses', 'theme_trema');
+$description = get_string('showehiddencategorycourses_desc', 'theme_trema');
+$default = true;
+$setting = new admin_setting_configcheckbox($name, $title, $description, $default, true, false);
+$setting->set_updatedcallback('theme_reset_all_caches');
+$page->add($setting);
+
 $settings->add($page);


### PR DESCRIPTION
This is to address the issue reported in #108 . It includes a new setting in the Trema theme's Content tab (bottom of the list):
![image](https://user-images.githubusercontent.com/3808579/189272726-9ea7e24d-2a6d-4826-8a33-40418fd75923.png)

Note (1): The Moodle search engine will still be able to find the courses in hidden categories when this option is enabled.

Note (2): The changes include new Trema strings so it is recommended to update the version number of the plugin.

Best regards,

Michael