### PR TITLE
Fix-168: PHP 8.2 compatibility issue with Admin Dashboard.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -188,6 +188,7 @@ function theme_trema_get_environment_issues() {
         $issues = \core\check\manager::get_security_checks();
 
         // Prevent warnings.
+        $environmentissues = [];
         $environmentissues["ok"]      = 0;
         $environmentissues["warning"] = 0;
         foreach ($issues as $issue) {


### PR DESCRIPTION
Hi @rmady ,

When I go to the Dashboard, I get the following error in Moodle 4.3 with PHP 8.2. Note that this error appears under the header so it is only visible in the source code view:

    Deprecated:  Automatic conversion of false to array is deprecated in /theme/trema/locallib.php on line 191

The reason this happens is that, if the following line fails to retrieve the information from the cache, the function returns 'false' and PHP 8.2 will not allow you to automatically convert this boolean into an array.

The attached PR addresses this issue. Hopefully, this will also address issue #168 .

Let me know if you have any questions or concerns.

Best regards,

Michael Milette